### PR TITLE
Escopa queries pelo banco SpotifyClone ao usar a tabela KEY_COLUMN_USAGE

### DIFF
--- a/tests/challenges.spec.js
+++ b/tests/challenges.spec.js
@@ -35,12 +35,13 @@ describe('Queries de seleção', () => {
         `SELECT COUNT(COLUMN_NAME) AS REFERENCE_COUNT
         FROM information_schema.KEY_COLUMN_USAGE
         WHERE
-          TABLE_NAME = '${table}'
+          TABLE_SCHEMA = 'SpotifyClone'
+            AND TABLE_NAME = '${table}'
             AND REFERENCED_TABLE_NAME = '${referencedTable}'
             AND REFERENCED_COLUMN_NAME = (
             SELECT COLUMN_NAME
                 FROM information_schema.KEY_COLUMN_USAGE
-                WHERE TABLE_NAME = '${referencedTable}' AND CONSTRAINT_NAME = 'PRIMARY'
+                WHERE TABLE_SCHEMA = 'SpotifyClone' AND TABLE_NAME = '${referencedTable}' AND CONSTRAINT_NAME = 'PRIMARY'
             );`,
         { type: 'SELECT' },
       );
@@ -52,7 +53,7 @@ describe('Queries de seleção', () => {
       const [{ PK_COUNT: pkCount }] = await sequelize.query(
         `SELECT COUNT(COLUMN_NAME) AS PK_COUNT
         FROM information_schema.KEY_COLUMN_USAGE
-        WHERE TABLE_NAME = '${table}' AND CONSTRAINT_NAME = 'PRIMARY';`,
+        WHERE TABLE_SCHEMA = 'SpotifyClone' AND TABLE_NAME = '${table}' AND CONSTRAINT_NAME = 'PRIMARY';`,
         { type: 'SELECT' },
       );
 
@@ -331,7 +332,7 @@ describe('Queries de seleção', () => {
       const [{ COLUMN_NAME: userIdColumn }] = await sequelize.query(`
         SELECT COLUMN_NAME
         FROM information_schema.KEY_COLUMN_USAGE
-        WHERE TABLE_NAME = '${userTable}' AND CONSTRAINT_NAME = 'PRIMARY';
+        WHERE TABLE_SCHEMA = 'SpotifyClone' AND TABLE_NAME = '${userTable}' AND CONSTRAINT_NAME = 'PRIMARY';
       `, { type: 'SELECT' });
       const userId = (await sequelize.query(
         `SELECT ${userIdColumn} FROM ${userTable} WHERE ${userColumn} = 'Bill';`,
@@ -417,7 +418,7 @@ describe('Queries de deleção', () => {
       const [{ COLUMN_NAME: userIdColumn }] = await sequelize.query(`
         SELECT COLUMN_NAME
         FROM information_schema.KEY_COLUMN_USAGE
-        WHERE TABLE_NAME = '${userTable}' AND CONSTRAINT_NAME = 'PRIMARY';
+        WHERE TABLE_SCHEMA = 'SpotifyClone' AND TABLE_NAME = '${userTable}' AND CONSTRAINT_NAME = 'PRIMARY';
       `, { type: 'SELECT' });
       const userId = (await sequelize.query(
         `SELECT ${userIdColumn} FROM ${userTable} WHERE ${userColumn} = 'Thati';`,
@@ -429,7 +430,7 @@ describe('Queries de deleção', () => {
       const userReferencedTables = await sequelize.query(`
         SELECT TABLE_NAME, COLUMN_NAME
         FROM information_schema.KEY_COLUMN_USAGE
-        WHERE REFERENCED_TABLE_NAME = '${userTable}';
+        WHERE TABLE_SCHEMA = 'SpotifyClone' AND REFERENCED_TABLE_NAME = '${userTable}';
       `, { type: 'SELECT' });
 
       for (let i = 0; i < userReferencedTables.length; i += 1) {


### PR DESCRIPTION
- No ambiente de testes a gente tem controle que teremos somente a base de dados `SpotifyClone` presente sobre a qual consultas serão feitas.
- Entretanto, como estudantes podem executar localmente os testes, é possível que haja presente mais de uma base, o que pode abrir brecha para existência de bases diferentes possuindo o mesmo nome de tabela, por exemplo, que pode levar a [essa consulta](https://github.com/betrybe/sd-0x-mysql-one-for-all/compare/escopa-database?expand=1#diff-a7a7cd9af8309a48b8cc0b839cfd171cL41-L43) retornando mais de 1 resultado, o que acarretaria no teste falhando localmente.